### PR TITLE
UIImage Function Deprecations

### DIFF
--- a/src/android/AdvancedImagePicker.java
+++ b/src/android/AdvancedImagePicker.java
@@ -160,7 +160,7 @@ public class AdvancedImagePicker extends CordovaPlugin {
             output.write(buffer, 0, bytesRead);
         }
         bytes = output.toByteArray();
-        return Base64.encodeToString(bytes, Base64.DEFAULT);
+        return Base64.encodeToString(bytes, Base64.NO_WRAP);
     }
 
     private String encodeImage(Uri uri, boolean asJpeg) throws FileNotFoundException {
@@ -177,7 +177,7 @@ public class AdvancedImagePicker extends CordovaPlugin {
             bm.compress(Bitmap.CompressFormat.PNG, 80, baos);
         }
         byte[] b = baos.toByteArray();
-        return Base64.encodeToString(b, Base64.DEFAULT);
+        return Base64.encodeToString(b, Base64.NO_WRAP);
     }
 
     private void returnError(AdvancedImagePickerErrorCodes errorCode) {

--- a/src/ios/AdvancedImagePicker.swift
+++ b/src/ios/AdvancedImagePicker.swift
@@ -151,9 +151,9 @@ import YPImagePicker
     func encodeImage(image: UIImage, asBase64: Bool, asJpeg: Bool) -> String {
         let imageData: NSData;
         if(asJpeg) {
-            imageData = image.jpegData(compressionQuality: 0.8)! as NSData;
+            imageData = UIImageJPEGRepresentation(image, 0.8)! as NSData;
         } else {
-            imageData = image.pngData()! as NSData;
+            imageData = UIImagePNGRepresentation(image)! as NSData;
         }
         if(asBase64) {
             return imageData.base64EncodedString();


### PR DESCRIPTION
This update is required to compile the plugin with the later xcode environments as the UIImage functions have been removed.

Also can you please update the plugin.xml file to correctly reflect the version number for install via cordova plugin add?