### PR TITLE
fix(ios): declare error codes enum within main class

### DIFF
--- a/src/ios/AdvancedImagePicker.swift
+++ b/src/ios/AdvancedImagePicker.swift
@@ -218,11 +218,11 @@ import YPImagePicker
         let result:CDVPluginResult = CDVPluginResult(status: CDVCommandStatus_OK);
         self.commandDelegate.send(result, callbackId: command.callbackId);
     }
-}
 
-enum ErrorCodes:NSNumber {
-    case UnsupportedAction = 1
-    case WrongJsonObject = 2
-    case PickerCanceled = 3
-    case UnknownError = 10
+    enum ErrorCodes:NSNumber {
+        case UnsupportedAction = 1
+        case WrongJsonObject = 2
+        case PickerCanceled = 3
+        case UnknownError = 10
+    }
 }


### PR DESCRIPTION
If the plugin is used together with "cordova-plugin-contacts-x", Xcode throws

```
Invalid redeclaration of 'ErrorCodes'
```

This is basically the [same fix as for the contacts plugin](https://github.com/EinfachHans/cordova-plugin-contacts-x/pull/38).

It would be great, if you can take a look at this issue / fix.

Best regards!