### PR TITLE
Update base plugins, fix Android Quirk

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,7 @@
         <source-file src="src/android/AdvancedImagePickerErrorCodes.java" target-dir="src/de/einfachhans/AdvancedImagePicker"/>
         <framework src="src/android/build.gradle" custom="true" type="gradleReference"/>
 
-        <preference name="ANDROID_IMAGE_PICKER_VERSION" default="1.2.8" />
+        <preference name="ANDROID_IMAGE_PICKER_VERSION" default="1.4.2" />
         <framework src="io.github.ParkSangGwon:tedimagepicker:$ANDROID_IMAGE_PICKER_VERSION"/>
     </platform>
 
@@ -42,7 +42,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="YPImagePicker" spec="5.2.1"/>
+                <pod name="YPImagePicker" spec="5.2.2"/>
             </pods>
         </podspec>
 

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@
 
 This [Cordova](https://cordova.apache.org) Plugin is for a better (multiple) ImagePicker with more options.
 
-It currently uses [Yummypets/YPImagePicker](https://github.com/Yummypets/YPImagePicker) (Version `5.2.1`) on iOS and 
-[ParkSangGwon/TedImagePicker](https://github.com/ParkSangGwon/TedImagePicker) (Default-Version `1.2.8`) on Android. 
+It currently uses [Yummypets/YPImagePicker](https://github.com/Yummypets/YPImagePicker) (Version `5.2.2`) on iOS and 
+[ParkSangGwon/TedImagePicker](https://github.com/ParkSangGwon/TedImagePicker) (Default-Version `1.4.2`) on Android. 
 
 **This Plugin is in active development!**
 
@@ -182,7 +182,7 @@ window.AdvancedImagePicker.cleanup(function() {
 
 ## Android
 
-- Currently, the Android Library is not able to select Images and Videos at the same Time. See reported Issue [here](https://github.com/ParkSangGwon/TedImagePicker/issues/40).
+- [FIXED?] Currently, the Android Library is not able to select Images and Videos at the same Time. See reported Issue [here](https://github.com/ParkSangGwon/TedImagePicker/issues/40).
 
 # Changelog
 


### PR DESCRIPTION
This fixes the Android quirk where you can only select images OR videos, not both.

When encoding the results, instead of using the selected type to determine whether to encode video or image, I checked the MIME type of the individual selected files.